### PR TITLE
Implement the Factory Design Pattern

### DIFF
--- a/mochimochi/classifier/binary/adagrad_rda.hpp
+++ b/mochimochi/classifier/binary/adagrad_rda.hpp
@@ -10,8 +10,9 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <fstream>
 #include "../../functions/enumerate.hpp"
+#include "../factory/binary_oml.hpp"
 
-class ADAGRAD_RDA {
+class ADAGRAD_RDA : public BinaryOML {
 private :
   const std::size_t kDim;
   const double kEta;
@@ -53,6 +54,10 @@ private :
   }
 
 public :
+
+  std::string name() const override {
+    return std::string("ADAGRAD_RDA");
+  }
 
   bool update(const Eigen::VectorXd& feature, const int label) {
     if (suffer_loss(feature, label) <= 0.0) { return false; }

--- a/mochimochi/classifier/binary/adagrad_rda.hpp
+++ b/mochimochi/classifier/binary/adagrad_rda.hpp
@@ -59,7 +59,7 @@ public :
     return std::string("ADAGRAD_RDA");
   }
 
-  bool update(const Eigen::VectorXd& feature, const int label) {
+  bool update(const Eigen::VectorXd& feature, const int label) override {
     if (suffer_loss(feature, label) <= 0.0) { return false; }
 
     _timestep++;
@@ -78,11 +78,11 @@ public :
     return true;
   }
 
-  int predict(const Eigen::VectorXd& x) const {
+  int predict(const Eigen::VectorXd& x) const override {
     return calculate_margin(x) > 0.0 ? 1 : -1;
   }
 
-  void save(const std::string& filename) {
+  void save(const std::string& filename) override {
     std::ofstream ofs(filename);
     assert(ofs);
     boost::archive::text_oarchive oa(ofs);
@@ -90,7 +90,7 @@ public :
     ofs.close();
   }
 
-  void load(const std::string& filename) {
+  void load(const std::string& filename) override {
     std::ifstream ifs(filename);
     assert(ifs);
     boost::archive::text_iarchive ia(ifs);

--- a/mochimochi/classifier/binary/adam.hpp
+++ b/mochimochi/classifier/binary/adam.hpp
@@ -11,8 +11,9 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <fstream>
 #include "../../functions/enumerate.hpp"
+#include "../factory/binary_oml.hpp"
 
-class ADAM {
+class ADAM : public BinaryOML {
 private :
   const std::size_t kDim;
 
@@ -47,7 +48,11 @@ private :
 
 public :
 
-  bool update(const Eigen::VectorXd& feature, const int label) {
+  std::string name() const override {
+    return std::string("ADAM");
+  }
+
+  bool update(const Eigen::VectorXd& feature, const int label) override {
     constexpr auto kAlpha = 0.001;
     constexpr auto kBeta1 = 0.9;
     constexpr auto kBeta2 = 0.999;
@@ -72,11 +77,11 @@ public :
     return true;
   }
 
-  int predict(const Eigen::VectorXd& feature) const {
+  int predict(const Eigen::VectorXd& feature) const override {
     return calculate_margin(feature) > 0.0 ? 1 : -1;
   }
 
-  void save(const std::string& filename) {
+  void save(const std::string& filename) override {
     std::ofstream ofs(filename);
     assert(ofs);
     boost::archive::text_oarchive oa(ofs);
@@ -84,7 +89,7 @@ public :
     ofs.close();
   }
 
-  void load(const std::string& filename) {
+  void load(const std::string& filename) override {
     std::ifstream ifs(filename);
     assert(ifs);
     boost::archive::text_iarchive ia(ifs);

--- a/mochimochi/classifier/binary/arow.hpp
+++ b/mochimochi/classifier/binary/arow.hpp
@@ -10,8 +10,9 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <fstream>
 #include "../../functions/enumerate.hpp"
+#include "../factory/binary_oml.hpp"
 
-class AROW {
+class AROW : public BinaryOML {
 private :
   const std::size_t kDim;
   const double kR;
@@ -38,6 +39,10 @@ public :
 
 private :
 
+  std::string name() const override {
+    return std::string("AROW");
+  }
+
   double suffer_loss(const double margin, const int label) const {
     return margin * label;
   }
@@ -57,7 +62,7 @@ private :
 
 public :
 
-  bool update(const Eigen::VectorXd& feature, const int label) {
+  bool update(const Eigen::VectorXd& feature, const int label) override {
     const auto margin = compute_margin(feature);
 
     if (suffer_loss(margin, label) >= 1.0) { return false; }
@@ -75,7 +80,7 @@ public :
     return true;
   }
 
-  int predict(const Eigen::VectorXd& x) const {
+  int predict(const Eigen::VectorXd& x) const override {
     return compute_margin(x) > 0.0 ? 1 : -1;
   }
 
@@ -83,7 +88,7 @@ public :
     return _means;
   }
 
-  void save(const std::string& filename) {
+  void save(const std::string& filename) override {
     std::ofstream ofs(filename);
     assert(ofs);
     boost::archive::text_oarchive oa(ofs);
@@ -91,7 +96,7 @@ public :
     ofs.close();
   }
 
-  void load(const std::string& filename) {
+  void load(const std::string& filename) override {
     std::ifstream ifs(filename);
     assert(ifs);
     boost::archive::text_iarchive ia(ifs);

--- a/mochimochi/classifier/binary/arow.hpp
+++ b/mochimochi/classifier/binary/arow.hpp
@@ -39,10 +39,6 @@ public :
 
 private :
 
-  std::string name() const override {
-    return std::string("AROW");
-  }
-
   double suffer_loss(const double margin, const int label) const {
     return margin * label;
   }
@@ -61,6 +57,10 @@ private :
   }
 
 public :
+
+  std::string name() const override {
+    return std::string("AROW");
+  }
 
   bool update(const Eigen::VectorXd& feature, const int label) override {
     const auto margin = compute_margin(feature);

--- a/mochimochi/classifier/binary/nherd.hpp
+++ b/mochimochi/classifier/binary/nherd.hpp
@@ -11,8 +11,9 @@
 #include <fstream>
 #include <functional>
 #include "../../functions/enumerate.hpp"
+#include "../factory/binary_oml.hpp"
 
-class NHERD {
+class NHERD : public BinaryOML {
 private :
   const std::size_t kDim;
   const double kC;
@@ -92,6 +93,10 @@ private :
   }
 
 public :
+
+  std::string name() const override {
+    return std::string("NHERD");
+  }
 
   bool update(const Eigen::VectorXd& feature, const int label) {
     const auto margin = compute_margin(feature);

--- a/mochimochi/classifier/binary/nherd.hpp
+++ b/mochimochi/classifier/binary/nherd.hpp
@@ -98,7 +98,7 @@ public :
     return std::string("NHERD");
   }
 
-  bool update(const Eigen::VectorXd& feature, const int label) {
+  bool update(const Eigen::VectorXd& feature, const int label) override {
     const auto margin = compute_margin(feature);
 
     if (suffer_loss(margin, label) >= 1.0) { return false; }
@@ -114,7 +114,7 @@ public :
     return true;
   }
 
-  int predict(const Eigen::VectorXd& x) const {
+  int predict(const Eigen::VectorXd& x) const override {
     return compute_margin(x) > 0.0 ? 1 : -1;
   }
 
@@ -122,7 +122,7 @@ public :
     return _means;
   }
 
-  void save(const std::string& filename) {
+  void save(const std::string& filename) override {
     std::ofstream ofs(filename);
     assert(ofs);
     boost::archive::text_oarchive oa(ofs);
@@ -130,7 +130,7 @@ public :
     ofs.close();
   }
 
-  void load(const std::string& filename) {
+  void load(const std::string& filename) override {
     std::ifstream ifs(filename);
     assert(ifs);
     boost::archive::text_iarchive ia(ifs);

--- a/mochimochi/classifier/binary/pa.hpp
+++ b/mochimochi/classifier/binary/pa.hpp
@@ -11,8 +11,9 @@
 #include <fstream>
 #include <functional>
 #include "../../functions/enumerate.hpp"
+#include "../factory/binary_oml.hpp"
 
-class PA {
+class PA : public BinaryOML {
 private :
   const std::size_t kDim;
   const double kC;
@@ -72,6 +73,10 @@ private :
   }
 
 public :
+
+  std::string name() const override {
+    return std::string("PA");
+  }
 
   bool update(const Eigen::VectorXd& feature, const int label) {
     const auto loss = suffer_loss(feature, label);

--- a/mochimochi/classifier/binary/pa.hpp
+++ b/mochimochi/classifier/binary/pa.hpp
@@ -35,23 +35,27 @@ public :
 
     // int select : switching the PA algorithm
     // 0 : PA
-    // 1 : PA-1
-    // 2 : PA-2
+    // 1 : PA-I
+    // 2 : PA-II
     switch(kSelect) {
     case 0 :
-      _compute_tau = [](const auto value, const auto loss) {
-        return loss / std::pow(std::abs(value), 2);
+      _compute_tau = [=](const auto value, const auto loss) {
+        /* Check for divide by zero in which case return zero for tau. */
+        /* If "value" is non-zero then proceed with division and return result. */
+        return (value == 0) ? 0 : loss / std::pow(std::abs(value), 2);
       };
       break;
     case 1 :
       _compute_tau = [=](const auto value, const auto loss) {
+        /* Possible divide by zero situation here if "value" is zero resulting in pa = inf. */
+        /* However, the inf is ignored when doing std::min(kC, pa). */
         const auto pa = loss / std::pow(std::abs(value), 2);
         return std::min(kC, pa);
       };
       break;
     case 2 :
       _compute_tau = [=](const auto value, const auto loss) {
-        return loss / (std::pow(std::abs(value), 2) + 1.0 / 2 * kC );
+        return loss / (std::pow(std::abs(value), 2) + 1.0 / 2 * kC);
       };
       break;
     default:
@@ -119,7 +123,7 @@ private :
   template <class Archive>
   void save(Archive& ar, const unsigned int version) const {
     std::vector<double> weight(_weight.data(), _weight.data() + _weight.size());
-    ar & boost::serialization::make_nvp("weigth", weight);
+    ar & boost::serialization::make_nvp("weight", weight);
     ar & boost::serialization::make_nvp("dimension", const_cast<std::size_t&>(kDim));
     ar & boost::serialization::make_nvp("C", const_cast<double&>(kC));
     ar & boost::serialization::make_nvp("select", const_cast<int&>(kSelect));

--- a/mochimochi/classifier/binary/pa.hpp
+++ b/mochimochi/classifier/binary/pa.hpp
@@ -47,10 +47,11 @@ public :
       break;
     case 1 :
       _compute_tau = [=](const auto value, const auto loss) {
-        /* Possible divide by zero situation here if "value" is zero resulting in pa = inf. */
-        /* However, the inf is ignored when doing std::min(kC, pa). */
+        /* Possible divide by zero situation if "value" is zero resulting in pa = inf. */
+        /* Check for this with a ternary operator and return kC if value == 0. */
+        /* Using the ternary check instead of just relying on std::min in case it's possible to get a -inf (not sure). */
         const auto pa = loss / std::pow(std::abs(value), 2);
-        return std::min(kC, pa);
+        return (value == 0) ? kC : std::min(kC, pa);
       };
       break;
     case 2 :

--- a/mochimochi/classifier/binary/pa.hpp
+++ b/mochimochi/classifier/binary/pa.hpp
@@ -82,7 +82,7 @@ public :
     return std::string("PA");
   }
 
-  bool update(const Eigen::VectorXd& feature, const int label) {
+  bool update(const Eigen::VectorXd& feature, const int label) override {
     const auto loss = suffer_loss(feature, label);
     functions::enumerate(feature.data(), feature.data() + feature.size(), 0,
                          [&](const std::size_t index, const double value) {
@@ -93,7 +93,7 @@ public :
     return true;
   }
 
-  int predict(const Eigen::VectorXd& x) const {
+  int predict(const Eigen::VectorXd& x) const override {
     return compute_margin(x) > 0.0 ? 1 : -1;
   }
 
@@ -101,7 +101,7 @@ public :
     return _weight;
   }
 
-  void save(const std::string& filename) {
+  void save(const std::string& filename) override {
     std::ofstream ofs(filename);
     assert(ofs);
     boost::archive::text_oarchive oa(ofs);
@@ -109,7 +109,7 @@ public :
     ofs.close();
   }
 
-  void load(const std::string& filename) {
+  void load(const std::string& filename) override {
     std::ifstream ifs(filename);
     assert(ifs);
     boost::archive::text_iarchive ia(ifs);

--- a/mochimochi/classifier/binary/scw.hpp
+++ b/mochimochi/classifier/binary/scw.hpp
@@ -82,7 +82,7 @@ public :
     return std::string("SCW");
   }
 
-  bool update(const Eigen::VectorXd& feature, const int label) {
+  bool update(const Eigen::VectorXd& feature, const int label) override {
     const auto v = compute_confidence(feature);
     const auto m = label * _means.dot(feature);
     const auto n = v + 1.0 / 2.0 * kC;
@@ -102,7 +102,7 @@ public :
     return true;
   }
 
-  int predict(const Eigen::VectorXd& x) const {
+  int predict(const Eigen::VectorXd& x) const override {
     return _means.dot(x) < 0.0 ? -1 : 1;
   }
 
@@ -110,7 +110,7 @@ public :
     return _means;
   }
 
-  void save(const std::string& filename) {
+  void save(const std::string& filename) override {
     std::ofstream ofs(filename);
     assert(ofs);
     boost::archive::text_oarchive oa(ofs);
@@ -118,7 +118,7 @@ public :
     ofs.close();
   }
 
-  void load(const std::string& filename) {
+  void load(const std::string& filename) override {
     std::ifstream ifs(filename);
     assert(ifs);
     boost::archive::text_iarchive ia(ifs);

--- a/mochimochi/classifier/binary/scw.hpp
+++ b/mochimochi/classifier/binary/scw.hpp
@@ -102,7 +102,7 @@ public :
     return true;
   }
 
-  int predict(const Eigen::VectorXd& x) {
+  int predict(const Eigen::VectorXd& x) const {
     return _means.dot(x) < 0.0 ? -1 : 1;
   }
 

--- a/mochimochi/classifier/binary/scw.hpp
+++ b/mochimochi/classifier/binary/scw.hpp
@@ -11,8 +11,9 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <fstream>
 #include "../../functions/enumerate.hpp"
+#include "../factory/binary_oml.hpp"
 
-class SCW {
+class SCW : public BinaryOML {
 private :
   const std::size_t kDim;
   const double kC;
@@ -76,6 +77,10 @@ private :
   }
 
 public :
+
+  std::string name() const override {
+    return std::string("SCW");
+  }
 
   bool update(const Eigen::VectorXd& feature, const int label) {
     const auto v = compute_confidence(feature);

--- a/mochimochi/classifier/factory/binary_oml.hpp
+++ b/mochimochi/classifier/factory/binary_oml.hpp
@@ -1,0 +1,22 @@
+#ifndef MOCHIMOCHI_BINARY_OML_INTERFACE_HPP_
+#define MOCHIMOCHI_BINARY_OML_INTERFACE_HPP_
+
+#include <string>
+#include <Eigen/Dense>
+
+using namespace std;
+
+/**
+ * The BinaryOML interface declares the operations that all concrete BinaryOML must implement.
+ */
+class BinaryOML {
+ public:
+  virtual ~BinaryOML() {}
+  virtual bool update(const Eigen::VectorXd& feature, const int label) = 0;
+  virtual int predict(const Eigen::VectorXd& x) const = 0;
+  virtual void save(const string& filename) = 0;
+  virtual void load(const string& filename) = 0;
+  virtual string name() const = 0;
+};
+
+#endif

--- a/mochimochi/classifier/factory/binary_oml_factory.hpp
+++ b/mochimochi/classifier/factory/binary_oml_factory.hpp
@@ -11,8 +11,12 @@
 #include <Eigen/Dense>
 
 #include "binary_oml.hpp"
+#include "../binary/adagrad_rda.hpp"
 #include "../binary/adam.hpp"
 #include "../binary/arow.hpp"
+#include "../binary/nherd.hpp"
+#include "../binary/pa.hpp"
+#include "../binary/scw.hpp"
 
 using namespace std;
 
@@ -57,30 +61,58 @@ public:
     return m_pBinaryOML->name();
   }
 
-  void train()
+  /**
+   * Train the model.
+   */
+  void train(string *pInput, int dim)
   {
-    std::cout << "TRAIN: " << m_pBinaryOML->name() << std::endl;
+    /* Convert training string input into training vector. */
+    auto data = utility::read_ones<int>(*pInput, dim);
+
+    /* Update the model with the new training data. */
+    m_pBinaryOML->update(data.second, data.first);
   }
 
-  void trainAndSave(const char* modelFilePath)
+  /**
+   * Train and save the model.
+   */
+  void trainAndSave(string *pInput, size_t dim, const string modelFilePath)
   {
-    std::cout << "TRAIN AND SAVE: " << modelFilePath << std::endl;
+    /* Convert training string input into data vector. */
+    auto data = utility::read_ones<int>(*pInput, dim);
+
+    /* Update the model with the new training data. */
+    m_pBinaryOML->update(data.second, data.first);
+
+    /* Serialize the model. */
     m_pBinaryOML->save(modelFilePath);
   }
 
-  void infer()
+  /**
+   * Infer/predicut the label of the given data input
+   */
+  int infer(string *pInput, size_t dim)
   {
-    std::cout << "INFER: " << m_pBinaryOML->name() << std::endl;
+    /* Convert inference string input into data vector. */
+    auto data = utility::read_ones<int>(*pInput, dim);
+
+    /* Invoke prediction method and return result. */
+    return m_pBinaryOML->predict(data.second);
   }
 
-  void load(const char* modelFilePath)
+  /**
+   * Load the model.
+   */
+  void load(const string modelFilePath)
   {
-    std::cout << "LOAD: " << modelFilePath << std::endl;
+    m_pBinaryOML->load(modelFilePath);
   }
 
-  void save(const char* modelFilePath)
+  /**
+   * Save the model.
+   */
+  void save(const string modelFilePath)
   {
-    std::cout << "SAVE: " << modelFilePath << std::endl;
     m_pBinaryOML->save(modelFilePath);
   }
 };

--- a/mochimochi/classifier/factory/binary_oml_factory.hpp
+++ b/mochimochi/classifier/factory/binary_oml_factory.hpp
@@ -255,7 +255,7 @@ public:
 
   /* The BinaryOML creator for SCW. */
   BinarySCWCreator(const size_t dim, const double c, const double eta)
-    : BinaryOMLCreator(new PA(dim, c, eta)) { }
+    : BinaryOMLCreator(new SCW(dim, c, eta)) { }
 };
 
 #endif // MOCHIMOCHI_BINARY_OML_FACTORY_HPP_

--- a/mochimochi/classifier/factory/binary_oml_factory.hpp
+++ b/mochimochi/classifier/factory/binary_oml_factory.hpp
@@ -1,0 +1,173 @@
+/**
+ * Implement the Factory Design Pattern to instanciate Online ML algorithm objects.
+ * https://refactoring.guru/design-patterns/factory-method/cpp/example
+ */
+
+#ifndef MOCHIMOCHI_BINARY_OML_FACTORY_HPP_
+#define MOCHIMOCHI_BINARY_OML_FACTORY_HPP_
+
+#include <string>
+#include <iostream>
+#include <Eigen/Dense>
+
+#include "binary_oml.hpp"
+#include "../binary/adam.hpp"
+#include "../binary/arow.hpp"
+
+using namespace std;
+
+/**
+ * The Creator class declares the factory method that is supposed to return an
+ * object of a Product class. The Creator's subclasses usually provide the
+ * implementation of this method.
+ */
+
+class BinaryOMLCreator {
+  /**
+   * Note that the Creator may also provide some default implementation of the
+   * factory method.
+   */
+protected:
+  BinaryOML* m_pBinaryOML;
+
+  /* The constructor. */
+  BinaryOMLCreator(BinaryOML* pBinaryOML)
+  {
+    m_pBinaryOML = pBinaryOML;
+  }
+
+public:
+  virtual ~BinaryOMLCreator() {
+    delete m_pBinaryOML;
+  };
+  
+  BinaryOML* FactoryMethod()
+  {
+    return m_pBinaryOML;
+  };
+  /**
+   * Despite its name, the Creator's primary responsibility isn't to create
+   * BinaryOML. Usually, it contains some core business logic that relies
+   * on BinaryOML objects, returned by the factory method. Subclasses can
+   * indirectly change that business logic by overriding the factory method
+   * and returning a different type of BinaryOML from it.
+   */
+  string name()
+  {
+    return m_pBinaryOML->name();
+  }
+
+  void train()
+  {
+    std::cout << "TRAIN: " << m_pBinaryOML->name() << std::endl;
+  }
+
+  void trainAndSave(const char* modelFilePath)
+  {
+    std::cout << "TRAIN AND SAVE: " << modelFilePath << std::endl;
+    m_pBinaryOML->save(modelFilePath);
+  }
+
+  void infer()
+  {
+    std::cout << "INFER: " << m_pBinaryOML->name() << std::endl;
+  }
+
+  void load(const char* modelFilePath)
+  {
+    std::cout << "LOAD: " << modelFilePath << std::endl;
+  }
+
+  void save(const char* modelFilePath)
+  {
+    std::cout << "SAVE: " << modelFilePath << std::endl;
+    m_pBinaryOML->save(modelFilePath);
+  }
+};
+
+/**
+ * Concrete Creators override the factory method in order to change the
+ * resulting BinaryOML's type.
+ */
+class BinaryADAGRADRDACreator : public BinaryOMLCreator {
+  /**
+   * Note that the signature of the method still uses the abstract product type,
+   * even though the concrete product is actually returned from the method. This
+   * way the Creator can stay independent of concrete product classes.
+   */
+
+public:
+  virtual ~BinaryADAGRADRDACreator() {}
+
+  /* The BinaryOML creator for ADAGRAD RDA. */
+  BinaryADAGRADRDACreator(const size_t dim, const double eta, const double lambda)
+    : BinaryOMLCreator(new ADAGRAD_RDA(dim, eta, lambda)) { }
+};
+
+
+/** 
+ * Concrete Creator for ADAGRAD RDA.
+ */
+class BinaryADAMCreator : public BinaryOMLCreator {
+  
+public:
+  virtual ~BinaryADAMCreator() {};
+
+  /* The BinaryOML creator for ADAM. */
+  BinaryADAMCreator(const size_t dim)
+    : BinaryOMLCreator(new ADAM(dim)) { }
+};
+
+/** 
+ * Concrete Creator for AROW.
+ */
+class BinaryAROWCreator : public BinaryOMLCreator {
+
+public:
+  virtual ~BinaryAROWCreator() {}
+
+  /* The BinaryOML creator for AROW. */
+  BinaryAROWCreator(const size_t dim, const double r)
+    : BinaryOMLCreator(new AROW(dim, r)) { }
+};
+
+/**
+ * Concrete Creator for NHERD.
+ */
+class BinaryNHERDCreator : public BinaryOMLCreator {
+
+public:
+  virtual ~BinaryNHERDCreator() {}
+
+  /* The BinaryOML creator for NHERD. */
+  BinaryNHERDCreator(const size_t dim, const double c, const int diagonal)
+    : BinaryOMLCreator(new NHERD(dim, c, diagonal)) { }
+};
+
+/**
+ * Concrete Creator for PA.
+ */
+class BinaryPACreator : public BinaryOMLCreator {
+
+public:
+  virtual ~BinaryPACreator() {}
+
+  /* The BinaryOML creator for PA. */
+  BinaryPACreator(const size_t dim, const double c, const int select)
+    : BinaryOMLCreator(new PA(dim, c, select)) { }
+};
+
+/**
+ * Concrete Creator for SCW.
+ */
+class BinarySCWCreator : public BinaryOMLCreator {
+
+public:
+  virtual ~BinarySCWCreator() {}
+
+  /* The BinaryOML creator for SCW. */
+  BinarySCWCreator(const size_t dim, const double c, const double eta)
+    : BinaryOMLCreator(new PA(dim, c, eta)) { }
+};
+
+#endif // MOCHIMOCHI_BINARY_OML_FACTORY_HPP_

--- a/mochimochi/classifier/factory/binary_oml_factory.hpp
+++ b/mochimochi/classifier/factory/binary_oml_factory.hpp
@@ -2,7 +2,7 @@
  * Implement the Factory Design Pattern to instanciate Online ML algorithm objects.
  * https://refactoring.guru/design-patterns/factory-method/cpp/example
  * 
- * Also implemented BinaryOMLCreatorInterface to give the option to develop the Proxy design pattern:
+ * Also implemented BinaryOMLInterface to give the option to develop the Proxy design pattern:
  * https://refactoring.guru/design-patterns/proxy/cpp/example#lang-features
  */
 
@@ -32,7 +32,7 @@ using namespace std;
  * whatever Proxy class will be im. As long as the client works with RealSubject using this interface,
  * you'll be able to pass it a proxy instead of a real subject.
  */
-class BinaryOMLCreatorInterface
+class BinaryOMLInterface
 {
 public:
   /**
@@ -77,7 +77,7 @@ public:
  * indirectly change that business logic by overriding the factory method
  * and returning a different type of BinaryOML from it.
 */
-class BinaryOMLCreator : public BinaryOMLCreatorInterface
+class BinaryOMLCreator : public BinaryOMLInterface
 {
   /**
    * Note that the Creator may also provide some default implementation of

--- a/mochimochi/classifier/factory/binary_oml_factory.hpp
+++ b/mochimochi/classifier/factory/binary_oml_factory.hpp
@@ -67,9 +67,9 @@ public:
 };
 
 /**
- * The Creator class declares the factory method that is supposed to return
- * an object of a Product class. The Creator's subclasses usually provide
- * the implementation of this method.
+ * The Creator class declares the factory method that returns an object
+ * of the BinaryOML class. The Creator's subclasses provide the
+ * implementation of this method.
  * 
  * Despite its name, the Creator's primary responsibility isn't to create
  * BinaryOML. Usually, it contains some core business logic that relies
@@ -175,9 +175,9 @@ public:
 class BinaryADAGRADRDACreator : public BinaryOMLCreator
 {
   /**
-   * Note that the signature of the method still uses the abstract product type,
-   * even though the concrete product is actually returned from the method. This
-   * way the Creator can stay independent of concrete product classes.
+   * Note that the signature of the method still uses the abstract binary OML type,
+   * even though the concrete binary OML is actually returned from the method. This
+   * way the Creator can stay independent of concrete binary OML classes.
    */
 public:
   virtual ~BinaryADAGRADRDACreator() {}

--- a/mochimochi/classifier/factory/binary_oml_factory.hpp
+++ b/mochimochi/classifier/factory/binary_oml_factory.hpp
@@ -1,6 +1,9 @@
 /**
  * Implement the Factory Design Pattern to instanciate Online ML algorithm objects.
  * https://refactoring.guru/design-patterns/factory-method/cpp/example
+ * 
+ * Also implemented BinaryOMLCreatorInterface to give the option to develop the Proxy design pattern:
+ * https://refactoring.guru/design-patterns/proxy/cpp/example#lang-features
  */
 
 #ifndef MOCHIMOCHI_BINARY_OML_FACTORY_HPP_
@@ -18,18 +21,67 @@
 #include "../binary/pa.hpp"
 #include "../binary/scw.hpp"
 
+#include "../../utility/load_svmlight_file.hpp"
+
 using namespace std;
 
-/**
- * The Creator class declares the factory method that is supposed to return an
- * object of a Product class. The Creator's subclasses usually provide the
- * implementation of this method.
- */
 
-class BinaryOMLCreator {
+
+/**
+ * This interface declares common operations for both BinaryOMLCreator and
+ * whatever Proxy class will be im. As long as the client works with RealSubject using this interface,
+ * you'll be able to pass it a proxy instead of a real subject.
+ */
+class BinaryOMLCreatorInterface
+{
+public:
   /**
-   * Note that the Creator may also provide some default implementation of the
-   * factory method.
+   * Name of the ML algorithm.
+   */
+  virtual string name() = 0;
+
+  /**
+   * Train/update the model with the given training input.
+   */
+  virtual void train(string *pInput, int dim) = 0;
+
+  /**
+   * Train/update the model with the given training input and save/serialize the model.
+   */
+  virtual void trainAndSave(string *pInput, size_t dim, const string modelFilePath) = 0;
+
+  /**
+   * Infer/predict the label with the given input.
+   */
+  virtual int infer(string *pInput, size_t dim) = 0;
+
+  /**
+   * Load a saved/serialized model.
+   */
+  virtual void load(const string modelFilePath) = 0;
+
+  /**
+   * Save/serialize the trained model.
+   */
+  virtual void save(const string modelFilePath) = 0;
+};
+
+/**
+ * The Creator class declares the factory method that is supposed to return
+ * an object of a Product class. The Creator's subclasses usually provide
+ * the implementation of this method.
+ * 
+ * Despite its name, the Creator's primary responsibility isn't to create
+ * BinaryOML. Usually, it contains some core business logic that relies
+ * on BinaryOML objects, returned by the factory method. Subclasses can
+ * indirectly change that business logic by overriding the factory method
+ * and returning a different type of BinaryOML from it.
+*/
+class BinaryOMLCreator : public BinaryOMLCreatorInterface
+{
+  /**
+   * Note that the Creator may also provide some default implementation of
+   * the factory method.
    */
 protected:
   BinaryOML* m_pBinaryOML;
@@ -41,7 +93,8 @@ protected:
   }
 
 public:
-  virtual ~BinaryOMLCreator() {
+  virtual ~BinaryOMLCreator()
+  {
     delete m_pBinaryOML;
   };
   
@@ -49,12 +102,10 @@ public:
   {
     return m_pBinaryOML;
   };
+  
+  
   /**
-   * Despite its name, the Creator's primary responsibility isn't to create
-   * BinaryOML. Usually, it contains some core business logic that relies
-   * on BinaryOML objects, returned by the factory method. Subclasses can
-   * indirectly change that business logic by overriding the factory method
-   * and returning a different type of BinaryOML from it.
+   * The name of the ML method tied to the instance of the Creator class.
    */
   string name()
   {
@@ -74,7 +125,7 @@ public:
   }
 
   /**
-   * Train and save the model.
+   * Train and save/serialize the model.
    */
   void trainAndSave(string *pInput, size_t dim, const string modelFilePath)
   {
@@ -89,7 +140,7 @@ public:
   }
 
   /**
-   * Infer/predicut the label of the given data input
+   * Infer/predict the label of the given data input
    */
   int infer(string *pInput, size_t dim)
   {
@@ -109,7 +160,7 @@ public:
   }
 
   /**
-   * Save the model.
+   * Save/serialize the model.
    */
   void save(const string modelFilePath)
   {
@@ -121,13 +172,13 @@ public:
  * Concrete Creators override the factory method in order to change the
  * resulting BinaryOML's type.
  */
-class BinaryADAGRADRDACreator : public BinaryOMLCreator {
+class BinaryADAGRADRDACreator : public BinaryOMLCreator
+{
   /**
    * Note that the signature of the method still uses the abstract product type,
    * even though the concrete product is actually returned from the method. This
    * way the Creator can stay independent of concrete product classes.
    */
-
 public:
   virtual ~BinaryADAGRADRDACreator() {}
 
@@ -140,8 +191,9 @@ public:
 /** 
  * Concrete Creator for ADAGRAD RDA.
  */
-class BinaryADAMCreator : public BinaryOMLCreator {
-  
+class BinaryADAMCreator : public BinaryOMLCreator
+{
+
 public:
   virtual ~BinaryADAMCreator() {};
 
@@ -153,7 +205,8 @@ public:
 /** 
  * Concrete Creator for AROW.
  */
-class BinaryAROWCreator : public BinaryOMLCreator {
+class BinaryAROWCreator : public BinaryOMLCreator
+{
 
 public:
   virtual ~BinaryAROWCreator() {}
@@ -166,7 +219,8 @@ public:
 /**
  * Concrete Creator for NHERD.
  */
-class BinaryNHERDCreator : public BinaryOMLCreator {
+class BinaryNHERDCreator : public BinaryOMLCreator
+{
 
 public:
   virtual ~BinaryNHERDCreator() {}
@@ -179,7 +233,8 @@ public:
 /**
  * Concrete Creator for PA.
  */
-class BinaryPACreator : public BinaryOMLCreator {
+class BinaryPACreator : public BinaryOMLCreator
+{
 
 public:
   virtual ~BinaryPACreator() {}
@@ -192,7 +247,8 @@ public:
 /**
  * Concrete Creator for SCW.
  */
-class BinarySCWCreator : public BinaryOMLCreator {
+class BinarySCWCreator : public BinaryOMLCreator
+{
 
 public:
   virtual ~BinarySCWCreator() {}


### PR DESCRIPTION
Implemented the Factory Design Pattern in `binary_oml_factor.hpp` and updated the algorithm code to plug into that pattern. 

The OrbitAI ML Server has been re-written from the ground up to interact with MochiMochi's new Factory Design Pattern. The OrbitAI pull request for that refactor is [here](https://github.com/georgeslabreche/opssat-orbitai/pull/45).

Also fixed a divide by zero issue with PA when feeding it 0 values as training data.